### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/tests/driver/test_auth.py
+++ b/tests/driver/test_auth.py
@@ -1,13 +1,13 @@
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
+from urllib.parse import urlparse
 
 import jwt
 import pytest
 from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 from starlette.requests import Request
-from urllib.parse import urlparse
 
 from framex.config import AuthConfig
 from framex.consts import DOCS_URL


### PR DESCRIPTION
Potential fix for [https://github.com/touale/FrameX-kit/security/code-scanning/5](https://github.com/touale/FrameX-kit/security/code-scanning/5)

General fix: avoid checking URLs via simple substring search. Instead, parse the URL and assert on structured components (host, scheme, path) or compare against exact expected values.

Best fix here: in `tests/driver/test_auth.py`, inside `TestAuthenticationIntegration.test_docs_redirects_when_not_authenticated`, replace:

```py
assert "oauth.example.com" in resp.headers["location"]
```

with logic that:

1. Parses the `location` header using `urllib.parse.urlparse`.
2. Asserts that `parsed.hostname` equals the expected host (`"oauth.example.com"`), and optionally that the scheme is HTTPS if desired.

Concretely:

- Add an import at the top of `tests/driver/test_auth.py`:

  ```py
  from urllib.parse import urlparse
  ```

- Change the assertion around line 199 to:

  ```py
  location = resp.headers["location"]
  parsed = urlparse(location)
  assert parsed.hostname == "oauth.example.com"
  ```

This keeps the existing functionality (verifying the redirect goes to the OAuth provider) but does so by checking the actual hostname rather than an arbitrary substring of the URL.

No other files need to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation for authentication redirect URL verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->